### PR TITLE
feat(billing): add trusted payment request middleware bypasses

### DIFF
--- a/src/middleware/apiKeyAuth.ts
+++ b/src/middleware/apiKeyAuth.ts
@@ -3,6 +3,11 @@ import crypto from 'crypto';
 import logger from '../utils/logger';
 import { prisma } from '../utils/prisma';
 import { AppError, ErrorType, sendErrorResponse } from '../utils/errorHandler';
+import {
+  BILLING_PAYMENT_OPERATION,
+  INTERNAL_OPERATION_HEADER,
+  markTrustedInternalOperation,
+} from '../utils/trustedInternalOperation';
 
 const ADMIN_SECRET = process.env.ADMIN_SECRET ?? '';
 const DASHBOARD_SECRET = process.env.DASHBOARD_SECRET ?? '';
@@ -97,6 +102,14 @@ export const apiKeyAuth = async (req: Request, res: Response, next: NextFunction
       }
       (req as any).workspaceContext = { workspace, source: 'dashboard' };
       (req as any).apiKeyData = null;
+      const internalOperation = req.headers[INTERNAL_OPERATION_HEADER] as string | undefined;
+      if (
+        internalOperation === BILLING_PAYMENT_OPERATION
+        && req.method === 'POST'
+        && req.path === '/verify'
+      ) {
+        markTrustedInternalOperation(req, BILLING_PAYMENT_OPERATION);
+      }
       return next();
     } catch (error) {
       logger.error('Error looking up workspace for dashboard auth:', error);

--- a/src/middleware/rateLimiter.ts
+++ b/src/middleware/rateLimiter.ts
@@ -3,6 +3,7 @@ import { getWorkspaceContext } from '../utils/workspaceContext';
 import { getRateLimit } from '../config/plans';
 import { getBillingConfig } from '../config/billingConfig';
 import { getRequestIp } from '../utils/requestIp';
+import { isTrustedBillingPaymentVerification } from '../utils/trustedInternalOperation';
 
 const WINDOW_MS = 60 * 1000;
 const PUBLIC_VERIFY_WINDOW_MS = 60 * 60 * 1000;
@@ -11,6 +12,11 @@ const PUBLIC_VERIFY_LIMIT = 6;
 const store = new Map<string, { count: number; windowStart: number }>();
 
 export const rateLimiter = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  if (isTrustedBillingPaymentVerification(req)) {
+    next();
+    return;
+  }
+
   const context = getWorkspaceContext(req);
   const requestIp = getRequestIp(req);
 

--- a/src/middleware/tierGate.ts
+++ b/src/middleware/tierGate.ts
@@ -11,6 +11,7 @@ import {
   type WorkspaceTier,
 } from '../config/plans';
 import { getBillingConfig, type BillingConfig } from '../config/billingConfig';
+import { isTrustedBillingPaymentVerification } from '../utils/trustedInternalOperation';
 
 const APP_URL = process.env.VERITAS_APP_URL ?? 'https://veritas.et';
 
@@ -389,6 +390,11 @@ export const verifyQuotaGate = async (
   res: Response,
   next: NextFunction,
 ): Promise<void> => {
+  if (isTrustedBillingPaymentVerification(req)) {
+    next();
+    return;
+  }
+
   const context = getWorkspaceContext(req);
   if (!context) { next(); return; }
 

--- a/src/middleware/verifyWebhookHook.ts
+++ b/src/middleware/verifyWebhookHook.ts
@@ -15,6 +15,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { notifyVerificationWebhooks } from '../utils/notifyVerificationWebhooks';
 import { getWorkspaceContext } from '../utils/workspaceContext';
+import { isTrustedBillingPaymentVerification } from '../utils/trustedInternalOperation';
 
 // Exact paths that trigger webhook firing. /verify-batch deliberately excluded.
 const SINGLE_VERIFY_PATHS = new Set<string>([
@@ -49,7 +50,10 @@ function providerFromPath(path: string): string | undefined {
 }
 
 export function verifyWebhookHook(req: Request, res: Response, next: NextFunction): void {
-  if (!SINGLE_VERIFY_PATHS.has(req.path)) {
+  if (
+    !SINGLE_VERIFY_PATHS.has(req.path)
+    || isTrustedBillingPaymentVerification(req)
+  ) {
     next();
     return;
   }

--- a/src/utils/trustedInternalOperation.ts
+++ b/src/utils/trustedInternalOperation.ts
@@ -1,0 +1,17 @@
+import { Request } from 'express';
+
+export const BILLING_PAYMENT_OPERATION = 'billing-payment';
+export const INTERNAL_OPERATION_HEADER = 'x-veritas-internal-operation';
+
+type TrustedInternalOperation = typeof BILLING_PAYMENT_OPERATION;
+
+export function markTrustedInternalOperation(
+  req: Request,
+  operation: TrustedInternalOperation,
+): void {
+  (req as any).trustedInternalOperation = operation;
+}
+
+export function isTrustedBillingPaymentVerification(req: Request): boolean {
+  return (req as any).trustedInternalOperation === BILLING_PAYMENT_OPERATION;
+}


### PR DESCRIPTION
Create a dedicated utility module for managing trusted internal requests. Update apiKeyAuth to mark qualifying billing payment requests, and add bypasses in quota gate, rate limiter, and webhook middleware to skip their validation for these trusted requests.