### PR TITLE
[codex] Reconcile Telebirr relay routing onto main

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,6 +522,19 @@ NODE_ENV=development # or production
 LOG_LEVEL=info       # or debug, error
 MISTRAL_API_KEY=your_mistral_api_key # Required for image verification
 SKIP_PRIMARY_VERIFICATION=false      # Set to true to bypass primary fetch
+FALLBACK_PROXIES=https://example.et/telebirr?reference=,https://relay.example/telebirr?reference=
+TELEBIRR_PROXY_KEY=your_proxy_key
+# Optional public labels in the same order. Raw relay URLs are never exposed.
+TELEBIRR_PROXY_LABELS=leul.et,Community relay 1
+# Runtime relay routing: hedge after 1s, cool failed routes for 60s,
+# allow at most two in flight, and cap the whole request at 10s.
+TELEBIRR_PROXY_TIMEOUT_MS=6000
+TELEBIRR_HEDGE_DELAY_MS=1000
+TELEBIRR_PROXY_COOLDOWN_MS=60000
+TELEBIRR_MAX_PARALLEL_PROXIES=2
+TELEBIRR_TOTAL_TIMEOUT_MS=10000
+# Independent timeout used when the status monitor checks every relay.
+STATUS_PROBE_TELEBIRR_PROXY_TIMEOUT_MS=12000
 ```
 
 You can get an API key for Mistral AI from [https://mistral.ai/](https://mistral.ai/)

--- a/render.yaml
+++ b/render.yaml
@@ -13,21 +13,33 @@ services:
         sync: false
       - key: STATUS_PROBE_TELEBIRR_REFERENCE
         sync: false
-      - key: STATUS_PROBE_CBE_REFERENCE
+      - key: STATUS_PROBE_TELEBIRR_PROXY_TIMEOUT_MS
+        value: "12000"
+      - key: TELEBIRR_PROXY_LABELS
         sync: false
-      - key: STATUS_PROBE_CBE_ACCOUNT_SUFFIX
+      - key: TELEBIRR_PROXY_TIMEOUT_MS
+        value: "6000"
+      - key: TELEBIRR_HEDGE_DELAY_MS
+        value: "1000"
+      - key: TELEBIRR_PROXY_COOLDOWN_MS
+        value: "60000"
+      - key: TELEBIRR_MAX_PARALLEL_PROXIES
+        value: "2"
+      - key: TELEBIRR_TOTAL_TIMEOUT_MS
+        value: "10000"
+      - key: STATUS_PROBE_CBE_LEGACY_REFERENCE
+        sync: false
+      - key: STATUS_PROBE_CBE_LEGACY_ACCOUNT_SUFFIX
+        sync: false
+      - key: STATUS_PROBE_CBE_NEW_URL
         sync: false
       - key: STATUS_PROBE_CBEBIRR_REFERENCE
         sync: false
       - key: STATUS_PROBE_CBEBIRR_PHONE
-        sync: false
-      - key: STATUS_PROBE_CBEBIRR_API_KEY
         sync: false
       - key: STATUS_PROBE_DASHEN_REFERENCE
         sync: false
       - key: STATUS_PROBE_ABYSSINIA_REFERENCE
         sync: false
       - key: STATUS_PROBE_ABYSSINIA_ACCOUNT_SUFFIX
-        sync: false
-      - key: STATUS_PROBE_MPESA_REFERENCE
         sync: false

--- a/src/services/statusProbeService.ts
+++ b/src/services/statusProbeService.ts
@@ -2,9 +2,10 @@ import { verifyAbyssinia } from './verifyAbyssinia';
 import { verifyCBE } from './verifyCBE';
 import { verifyCBEBirr } from './verifyCBEBirr';
 import { verifyDashen } from './verifyDashen';
-import { verifyTelebirr } from './verifyTelebirr';
+import { probeTelebirrProxyPool } from './verifyTelebirr';
 import type {
   StatusCapabilities,
+  TelebirrProbeDetails,
   StatusProbeResult,
   StatusProvider,
   StatusProbeResultCode,
@@ -43,12 +44,18 @@ async function withTimeout<T>(operation: Promise<T>, timeoutMs: number): Promise
 function providerOperation(
   provider: StatusProvider,
   env: NodeJS.ProcessEnv,
-): (() => Promise<boolean>) | null {
+): (() => Promise<{ healthy: boolean; telebirr?: TelebirrProbeDetails }>) | null {
   switch (provider) {
     case 'telebirr': {
       const reference = env.STATUS_PROBE_TELEBIRR_REFERENCE;
       if (!reference?.trim()) return null;
-      return async () => (await verifyTelebirr(reference)) !== null;
+      return async () => {
+        const telebirr = await probeTelebirrProxyPool(reference, env);
+        return {
+          healthy: Boolean(telebirr.activeRouteId),
+          telebirr,
+        };
+      };
     }
     case 'cbe': {
       const reference =
@@ -58,13 +65,16 @@ function providerOperation(
         env.STATUS_PROBE_CBE_LEGACY_ACCOUNT_SUFFIX ??
         env.STATUS_PROBE_CBE_ACCOUNT_SUFFIX;
       if (!reference?.trim() || !suffix?.trim()) return null;
-      return async () =>
-        (await verifyCBE(reference, suffix)).success;
+      return async () => ({
+        healthy: (await verifyCBE(reference, suffix)).success,
+      });
     }
     case 'cbe-new': {
       const receiptUrl = env.STATUS_PROBE_CBE_NEW_URL;
       if (!receiptUrl?.trim()) return null;
-      return async () => (await verifyCBE(receiptUrl)).success;
+      return async () => ({
+        healthy: (await verifyCBE(receiptUrl)).success,
+      });
     }
     case 'cbe-birr': {
       const reference = env.STATUS_PROBE_CBEBIRR_REFERENCE;
@@ -72,19 +82,25 @@ function providerOperation(
       if (!reference?.trim() || !phone?.trim()) return null;
       return async () => {
         const result = await verifyCBEBirr(reference, phone);
-        return !('success' in result) || result.success !== false;
+        return {
+          healthy: !('success' in result) || result.success !== false,
+        };
       };
     }
     case 'dashen': {
       const reference = env.STATUS_PROBE_DASHEN_REFERENCE;
       if (!reference?.trim()) return null;
-      return async () => (await verifyDashen(reference)).success;
+      return async () => ({
+        healthy: (await verifyDashen(reference)).success,
+      });
     }
     case 'abyssinia': {
       const reference = env.STATUS_PROBE_ABYSSINIA_REFERENCE;
       const suffix = env.STATUS_PROBE_ABYSSINIA_ACCOUNT_SUFFIX;
       if (!reference?.trim() || !suffix?.trim()) return null;
-      return async () => (await verifyAbyssinia(reference, suffix)).success;
+      return async () => ({
+        healthy: (await verifyAbyssinia(reference, suffix)).success,
+      });
     }
   }
 }
@@ -103,6 +119,16 @@ export function classifyProbeResult(input: {
   return input.durationMs >= (input.slowMs ?? DEFAULT_SLOW_MS)
     ? 'UPSTREAM_SLOW'
     : 'PROBE_OK';
+}
+
+export function isHealthyProbeResultCode(
+  resultCode: StatusProbeResultCode,
+): boolean {
+  return (
+    resultCode === 'PROBE_OK' ||
+    resultCode === 'UPSTREAM_SLOW' ||
+    resultCode === 'FALLBACK_ACTIVE'
+  );
 }
 
 export async function runStatusProviderProbe(
@@ -126,31 +152,43 @@ export async function runStatusProviderProbe(
   const slowMs = parsePositiveInteger(env.STATUS_PROBE_SLOW_MS, DEFAULT_SLOW_MS);
   const startedAt = performance.now();
   let healthy = false;
+  let telebirr: TelebirrProbeDetails | undefined;
   let error: unknown;
   try {
-    healthy = await runWithSensitiveLogsSuppressed(() =>
+    const outcome = await runWithSensitiveLogsSuppressed(() =>
       withTimeout(operation(), timeoutMs),
     );
+    healthy = outcome.healthy;
+    telebirr = outcome.telebirr;
   } catch (caught) {
     error = caught;
   }
   const durationMs = Math.round(performance.now() - startedAt);
-  const resultCode = classifyProbeResult({
+  let resultCode = classifyProbeResult({
     configured: true,
     healthy,
     durationMs,
     slowMs,
     error,
   });
+  if (telebirr) {
+    if (!telebirr.activeRouteId) {
+      resultCode = 'ALL_ROUTES_UNAVAILABLE';
+    } else if (!telebirr.preferredRouteAvailable) {
+      resultCode = 'FALLBACK_ACTIVE';
+    }
+  }
+
+  const pathHealthy = isHealthyProbeResultCode(resultCode);
 
   return {
     provider,
-    reachable: resultCode === 'PROBE_OK' || resultCode === 'UPSTREAM_SLOW',
-    verificationPathHealthy:
-      resultCode === 'PROBE_OK' || resultCode === 'UPSTREAM_SLOW',
+    reachable: pathHealthy,
+    verificationPathHealthy: pathHealthy,
     durationMs,
     checkedAt,
     resultCode,
+    ...(telebirr ? { telebirr } : {}),
   };
 }
 

--- a/src/services/verifyTelebirr.ts
+++ b/src/services/verifyTelebirr.ts
@@ -1,6 +1,10 @@
 import axios, { AxiosError } from "axios";
 import * as cheerio from "cheerio";
 import logger from '../utils/logger';
+import type {
+    TelebirrProbeDetails,
+    TelebirrRouteStatus
+} from '../types/statusProbe';
 
 export interface TelebirrReceipt {
     payerName: string;
@@ -289,7 +293,7 @@ function parseTelebirrJson(jsonData: any): TelebirrReceipt | null {
     try {
         // Check if the response has the expected structure
         if (!jsonData || !jsonData.success || !jsonData.data) {
-            logger.warn("Invalid JSON structure from proxy endpoint", { jsonData });
+            logger.warn("Invalid JSON structure from proxy endpoint.");
             return null;
         }
 
@@ -311,7 +315,9 @@ function parseTelebirrJson(jsonData: any): TelebirrReceipt | null {
             customerNote: data.customerNote || ""
         };
     } catch (error) {
-        logger.error("Error parsing JSON from proxy endpoint", { error, jsonData });
+        logger.error("Error parsing JSON from proxy endpoint.", {
+            error: error instanceof Error ? error.message : 'Unknown parse error'
+        });
         return null;
     }
 }
@@ -326,19 +332,14 @@ async function fetchFromPrimarySource(reference: string, baseUrl: string): Promi
     const url = `${baseUrl}${reference}`;
 
     try {
-        logger.info(`Attempting to fetch Telebirr receipt from primary source: ${url}`);
+        logger.info('Attempting to fetch Telebirr receipt from primary source.');
         const response = await axios.get(url, { timeout: 30000 }); // 30 second timeout to be safe
         logger.debug(`Received response with status: ${response.status}`);
 
         const extractedData = scrapeTelebirrReceipt(response.data);
 
-        logger.debug("Extracted data from HTML:", extractedData);
-        logger.info(`Successfully extracted Telebirr data for reference: ${reference}`, {
-            receiptNo: extractedData.receiptNo,
-            payerName: extractedData.payerName,
-            transactionStatus: extractedData.transactionStatus,
-            settledAmount: extractedData.settledAmount,
-            serviceFee: extractedData.serviceFee
+        logger.info('Successfully extracted Telebirr data from primary source.', {
+            transactionStatus: extractedData.transactionStatus
         });
 
         return extractedData;
@@ -351,11 +352,10 @@ async function fetchFromPrimarySource(reference: string, baseUrl: string): Promi
         const axiosError = error as AxiosError;
         const responseDetails = axiosError.response ? {
             status: axiosError.response.status,
-            statusText: axiosError.response.statusText,
-            responseData: axiosError.response.data
+            statusText: axiosError.response.statusText
         } : {};
 
-        logger.error(`Error fetching Telebirr receipt from primary source ${url}:`, {
+        logger.error('Error fetching Telebirr receipt from primary source.', {
             error: errorMessage,
             stack: errorStack,
             ...responseDetails
@@ -367,10 +367,17 @@ async function fetchFromPrimarySource(reference: string, baseUrl: string): Promi
 
 export class TelebirrVerificationError extends Error {
     public details?: string;
-    constructor(message: string, details?: string) {
+    public kind: 'transport' | 'domain' | 'cancelled';
+
+    constructor(
+        message: string,
+        details?: string,
+        kind: 'transport' | 'domain' | 'cancelled' = 'domain'
+    ) {
         super(message);
         this.name = 'TelebirrVerificationError';
         this.details = details;
+        this.kind = kind;
     }
 }
 
@@ -380,14 +387,29 @@ export class TelebirrVerificationError extends Error {
  * @param proxyUrl The proxy URL to fetch the receipt from
  * @returns The parsed receipt data or null if failed
  */
-async function fetchFromProxySource(reference: string, proxyUrl: string): Promise<TelebirrReceipt | null> {
-    const proxyKey = process.env.TELEBIRR_PROXY_KEY || '';
+interface ProxyFetchOptions {
+    proxyKey?: string;
+    timeoutMs?: number;
+    signal?: AbortSignal;
+    relayLabel?: string;
+}
+
+async function fetchFromProxySource(
+    reference: string,
+    proxyUrl: string,
+    options: ProxyFetchOptions = {}
+): Promise<TelebirrReceipt | null> {
+    const proxyKey = options.proxyKey ?? process.env.TELEBIRR_PROXY_KEY ?? '';
     const url = `${proxyUrl}${reference}${proxyKey ? `&key=${proxyKey}` : ''}`;
+    const relayLabel = options.relayLabel ?? 'configured relay';
 
     try {
-        logger.info(`Attempting to fetch Telebirr receipt from proxy: ${url}`);
+        logger.info('Attempting Telebirr verification through relay.', {
+            relay: relayLabel
+        });
         const response = await axios.get(url, {
-            timeout: 30000,
+            timeout: options.timeoutMs ?? 30000,
+            signal: options.signal,
             headers: {
                 'Accept': 'application/json',
                 'User-Agent': 'VerifierAPI/1.0'
@@ -408,8 +430,14 @@ async function fetchFromProxySource(reference: string, proxyUrl: string): Promis
         }
 
         if (data && data.success === false && data.error) {
-            logger.error(`Proxy returned explicit error: ${data.error}`);
-            throw new TelebirrVerificationError(data.error, data.details);
+            logger.info('Telebirr relay returned a domain response.', {
+                relay: relayLabel
+            });
+            throw new TelebirrVerificationError(
+                data.error,
+                data.details,
+                'domain'
+            );
         }
 
         const extractedData = parseTelebirrJson(data);
@@ -418,10 +446,8 @@ async function fetchFromProxySource(reference: string, proxyUrl: string): Promis
             return scrapeTelebirrReceipt(response.data);
         }
 
-        logger.debug("Extracted data from JSON:", extractedData);
-        logger.info(`Successfully extracted Telebirr data from proxy for reference: ${reference}`, {
-            receiptNo: extractedData.receiptNo,
-            payerName: extractedData.payerName,
+        logger.info('Successfully extracted Telebirr data from relay.', {
+            relay: relayLabel,
             transactionStatus: extractedData.transactionStatus
         });
 
@@ -432,42 +458,461 @@ async function fetchFromProxySource(reference: string, proxyUrl: string): Promis
         }
 
         const axiosError = error as AxiosError;
-        if (axiosError.code === 'ETIMEDOUT' || axiosError.code === 'ECONNABORTED' || axiosError.code === 'ECONNREFUSED') {
-            const detailMsg = axiosError.message;
-            throw new TelebirrVerificationError("The fallback proxy server (leul.et) is unreachable or timed out.", detailMsg);
+        if (axios.isCancel(error) || axiosError.code === 'ERR_CANCELED') {
+            throw new TelebirrVerificationError(
+                'The relay request was cancelled.',
+                undefined,
+                'cancelled'
+            );
         }
 
-        const errorMessage = error instanceof Error ? error.message : "Unknown error";
-        const errorStack = error instanceof Error ? error.stack : undefined;
+        const isTransportFailure =
+            !axiosError.response ||
+            (axiosError.response.status ?? 0) >= 500 ||
+            axiosError.code === 'ETIMEDOUT' ||
+            axiosError.code === 'ECONNABORTED' ||
+            axiosError.code === 'ECONNREFUSED';
 
-        const responseDetails = axiosError.response ? {
-            status: axiosError.response.status,
-            statusText: axiosError.response.statusText,
-            responseData: axiosError.response.data
-        } : {};
+        if (isTransportFailure) {
+            logger.warn('Telebirr relay is unreachable or timed out.', {
+                relay: relayLabel,
+                code: axiosError.code,
+                status: axiosError.response?.status
+            });
+            throw new TelebirrVerificationError(
+                'The fallback relay is unreachable or timed out.',
+                axiosError.message,
+                'transport'
+            );
+        }
 
-        logger.error(`Error fetching Telebirr receipt from proxy ${url}:`, {
-            error: errorMessage,
-            stack: errorStack,
-            ...responseDetails
+        logger.info('Telebirr relay rejected the receipt request.', {
+            relay: relayLabel,
+            status: axiosError.response?.status
         });
 
         return null;
     }
 }
 
+interface TelebirrProxyDescriptor {
+    id: string;
+    label: string;
+    role: TelebirrRouteStatus['role'];
+    url: string;
+}
+
+function positiveInteger(value: string | undefined, fallback: number): number {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function safePublicLabel(value: string | undefined): string | null {
+    const normalized = value?.trim().replace(/\s+/g, ' ');
+    if (!normalized || !/^[A-Za-z0-9 ._-]{1,32}$/.test(normalized)) return null;
+    return normalized;
+}
+
+function defaultProxyLabel(url: string, index: number): string {
+    if (index === 0) {
+        try {
+            const hostname = new URL(url).hostname.toLowerCase();
+            if (hostname === 'leul.et' || hostname.endsWith('.leul.et')) {
+                return 'leul.et';
+            }
+        } catch {
+            // Invalid URLs are reported as unavailable without exposing their value.
+        }
+        return 'Preferred relay';
+    }
+    return `Community relay ${index}`;
+}
+
+export function getTelebirrProxyDescriptors(
+    env: NodeJS.ProcessEnv = process.env
+): TelebirrProxyDescriptor[] {
+    const urls = (env.FALLBACK_PROXIES ?? '')
+        .split(',')
+        .map(url => url.trim())
+        .filter(Boolean);
+    const labels = (env.TELEBIRR_PROXY_LABELS ?? '')
+        .split(',')
+        .map(label => safePublicLabel(label));
+
+    return urls.map((url, index) => ({
+        id: index === 0 ? 'preferred' : `relay-${index}`,
+        label: labels[index] ?? defaultProxyLabel(url, index),
+        role: index === 0 ? 'preferred' : 'fallback',
+        url
+    }));
+}
+
+interface TelebirrProxyRuntimeState {
+    consecutiveFailures: number;
+    circuitOpenUntil: number;
+    lastSuccessAt: number;
+    averageLatencyMs: number | null;
+}
+
+interface TelebirrProxyAttemptResult {
+    kind: 'attempt';
+    token: number;
+    descriptor: TelebirrProxyDescriptor;
+    receipt: TelebirrReceipt | null;
+    failureKind: TelebirrVerificationError['kind'] | null;
+    latencyMs: number;
+}
+
+interface TelebirrProxyInFlight {
+    token: number;
+    descriptor: TelebirrProxyDescriptor;
+    controller: AbortController;
+    promise: Promise<TelebirrProxyAttemptResult>;
+}
+
+type TelebirrProxyPoolEvent =
+    | TelebirrProxyAttemptResult
+    | { kind: 'hedge' }
+    | { kind: 'deadline' };
+
+const telebirrProxyRuntime = new Map<string, TelebirrProxyRuntimeState>();
+let activeTelebirrProxyUrl: string | null = null;
+
+function proxyRuntimeState(url: string): TelebirrProxyRuntimeState {
+    const current = telebirrProxyRuntime.get(url);
+    if (current) return current;
+
+    const initial: TelebirrProxyRuntimeState = {
+        consecutiveFailures: 0,
+        circuitOpenUntil: 0,
+        lastSuccessAt: 0,
+        averageLatencyMs: null
+    };
+    telebirrProxyRuntime.set(url, initial);
+    return initial;
+}
+
+function recordProxySuccess(
+    descriptor: TelebirrProxyDescriptor,
+    latencyMs: number,
+    makeActive: boolean
+): void {
+    const state = proxyRuntimeState(descriptor.url);
+    state.consecutiveFailures = 0;
+    state.circuitOpenUntil = 0;
+    state.lastSuccessAt = Date.now();
+    state.averageLatencyMs =
+        state.averageLatencyMs === null
+            ? latencyMs
+            : Math.round((state.averageLatencyMs * 0.7) + (latencyMs * 0.3));
+
+    if (makeActive) {
+        activeTelebirrProxyUrl = descriptor.url;
+    }
+}
+
+function recordProxyTransportFailure(
+    descriptor: TelebirrProxyDescriptor,
+    cooldownMs: number
+): void {
+    const state = proxyRuntimeState(descriptor.url);
+    state.consecutiveFailures += 1;
+    state.circuitOpenUntil = Date.now() + cooldownMs;
+
+    if (activeTelebirrProxyUrl === descriptor.url) {
+        activeTelebirrProxyUrl = null;
+    }
+}
+
+function orderedAvailableProxies(
+    descriptors: TelebirrProxyDescriptor[],
+    now: number
+): TelebirrProxyDescriptor[] {
+    const originalOrder = new Map(
+        descriptors.map((descriptor, index) => [descriptor.url, index])
+    );
+
+    return descriptors
+        .filter(descriptor => proxyRuntimeState(descriptor.url).circuitOpenUntil <= now)
+        .sort((left, right) => {
+            const leftIsActive = left.url === activeTelebirrProxyUrl;
+            const rightIsActive = right.url === activeTelebirrProxyUrl;
+            if (leftIsActive !== rightIsActive) return leftIsActive ? -1 : 1;
+
+            if (left.role !== right.role) {
+                return left.role === 'preferred' ? -1 : 1;
+            }
+
+            const leftState = proxyRuntimeState(left.url);
+            const rightState = proxyRuntimeState(right.url);
+            if (leftState.lastSuccessAt !== rightState.lastSuccessAt) {
+                return rightState.lastSuccessAt - leftState.lastSuccessAt;
+            }
+
+            const leftLatency = leftState.averageLatencyMs ?? Number.MAX_SAFE_INTEGER;
+            const rightLatency = rightState.averageLatencyMs ?? Number.MAX_SAFE_INTEGER;
+            if (leftLatency !== rightLatency) return leftLatency - rightLatency;
+
+            return (
+                (originalOrder.get(left.url) ?? Number.MAX_SAFE_INTEGER) -
+                (originalOrder.get(right.url) ?? Number.MAX_SAFE_INTEGER)
+            );
+        });
+}
+
+async function verifyWithTelebirrProxyPool(
+    reference: string,
+    descriptors: TelebirrProxyDescriptor[],
+    env: NodeJS.ProcessEnv
+): Promise<TelebirrReceipt | null> {
+    const proxyTimeoutMs = positiveInteger(
+        env.TELEBIRR_PROXY_TIMEOUT_MS,
+        6_000
+    );
+    const hedgeDelayMs = positiveInteger(
+        env.TELEBIRR_HEDGE_DELAY_MS,
+        1_000
+    );
+    const cooldownMs = positiveInteger(
+        env.TELEBIRR_PROXY_COOLDOWN_MS,
+        60_000
+    );
+    const totalTimeoutMs = positiveInteger(
+        env.TELEBIRR_TOTAL_TIMEOUT_MS,
+        10_000
+    );
+    const maxParallel = Math.min(
+        Math.max(1, positiveInteger(env.TELEBIRR_MAX_PARALLEL_PROXIES, 2)),
+        4
+    );
+    const proxyKey = env.TELEBIRR_PROXY_KEY ?? '';
+    const deadlineAt = Date.now() + totalTimeoutMs;
+    const candidates = orderedAvailableProxies(descriptors, Date.now());
+
+    if (candidates.length === 0) {
+        logger.warn('All Telebirr relay circuits are cooling down.');
+        return null;
+    }
+
+    let nextCandidateIndex = 0;
+    let nextToken = 0;
+    const inFlight: TelebirrProxyInFlight[] = [];
+    let deadlineTimer: NodeJS.Timeout | undefined;
+    const deadlinePromise = new Promise<TelebirrProxyPoolEvent>(resolve => {
+        deadlineTimer = setTimeout(
+            () => resolve({ kind: 'deadline' }),
+            totalTimeoutMs
+        );
+    });
+
+    const startNextCandidate = (): boolean => {
+        if (
+            nextCandidateIndex >= candidates.length ||
+            inFlight.length >= maxParallel
+        ) {
+            return false;
+        }
+
+        const descriptor = candidates[nextCandidateIndex++];
+        const token = nextToken++;
+        const controller = new AbortController();
+        const timeoutMs = Math.max(
+            1,
+            Math.min(proxyTimeoutMs, deadlineAt - Date.now())
+        );
+        const startedAt = performance.now();
+        const promise = (async (): Promise<TelebirrProxyAttemptResult> => {
+            try {
+                const receipt = await fetchFromProxySource(
+                    reference,
+                    descriptor.url,
+                    {
+                        proxyKey,
+                        timeoutMs,
+                        signal: controller.signal,
+                        relayLabel: descriptor.label
+                    }
+                );
+                return {
+                    kind: 'attempt',
+                    token,
+                    descriptor,
+                    receipt:
+                        receipt && isValidReceipt(receipt)
+                            ? receipt
+                            : null,
+                    failureKind: null,
+                    latencyMs: Math.round(performance.now() - startedAt)
+                };
+            } catch (error) {
+                return {
+                    kind: 'attempt',
+                    token,
+                    descriptor,
+                    receipt: null,
+                    failureKind:
+                        error instanceof TelebirrVerificationError
+                            ? error.kind
+                            : 'transport',
+                    latencyMs: Math.round(performance.now() - startedAt)
+                };
+            }
+        })();
+
+        inFlight.push({ token, descriptor, controller, promise });
+        return true;
+    };
+
+    startNextCandidate();
+
+    try {
+        while (inFlight.length > 0) {
+            const race: Promise<TelebirrProxyPoolEvent>[] = [
+                ...inFlight.map(attempt => attempt.promise),
+                deadlinePromise
+            ];
+            let hedgeTimer: NodeJS.Timeout | undefined;
+
+            if (
+                nextCandidateIndex < candidates.length &&
+                inFlight.length < maxParallel
+            ) {
+                race.push(
+                    new Promise<TelebirrProxyPoolEvent>(resolve => {
+                        hedgeTimer = setTimeout(
+                            () => resolve({ kind: 'hedge' }),
+                            Math.min(
+                                hedgeDelayMs,
+                                Math.max(1, deadlineAt - Date.now())
+                            )
+                        );
+                    })
+                );
+            }
+
+            const event = await Promise.race(race);
+            if (hedgeTimer) clearTimeout(hedgeTimer);
+
+            if (event.kind === 'deadline') {
+                for (const attempt of inFlight) {
+                    recordProxyTransportFailure(attempt.descriptor, cooldownMs);
+                    attempt.controller.abort();
+                }
+                logger.warn('Telebirr relay pool reached its total deadline.');
+                return null;
+            }
+
+            if (event.kind === 'hedge') {
+                startNextCandidate();
+                continue;
+            }
+
+            const completedIndex = inFlight.findIndex(
+                attempt => attempt.token === event.token
+            );
+            if (completedIndex >= 0) {
+                inFlight.splice(completedIndex, 1);
+            }
+
+            if (event.receipt) {
+                recordProxySuccess(
+                    event.descriptor,
+                    event.latencyMs,
+                    true
+                );
+                for (const attempt of inFlight) {
+                    attempt.controller.abort();
+                }
+                return event.receipt;
+            }
+
+            if (event.failureKind === 'transport') {
+                recordProxyTransportFailure(event.descriptor, cooldownMs);
+            }
+
+            startNextCandidate();
+        }
+
+        return null;
+    } finally {
+        if (deadlineTimer) clearTimeout(deadlineTimer);
+    }
+}
+
+export async function probeTelebirrProxyPool(
+    reference: string,
+    env: NodeJS.ProcessEnv = process.env
+): Promise<TelebirrProbeDetails> {
+    const descriptors = getTelebirrProxyDescriptors(env);
+    const timeoutMs = positiveInteger(
+        env.STATUS_PROBE_TELEBIRR_PROXY_TIMEOUT_MS,
+        12_000
+    );
+    const cooldownMs = positiveInteger(
+        env.TELEBIRR_PROXY_COOLDOWN_MS,
+        60_000
+    );
+    const proxyKey = env.TELEBIRR_PROXY_KEY ?? '';
+
+    const routes = await Promise.all(
+        descriptors.map(async (descriptor): Promise<TelebirrRouteStatus> => {
+            const startedAt = performance.now();
+            try {
+                const receipt = await fetchFromProxySource(reference, descriptor.url, {
+                    proxyKey,
+                    timeoutMs,
+                    relayLabel: descriptor.label
+                });
+                const operational = Boolean(receipt && isValidReceipt(receipt));
+                const latencyMs = Math.round(performance.now() - startedAt);
+                if (operational) {
+                    recordProxySuccess(descriptor, latencyMs, false);
+                }
+                return {
+                    id: descriptor.id,
+                    label: descriptor.label,
+                    role: descriptor.role,
+                    status: operational ? 'operational' : 'unavailable',
+                    latencyMs
+                };
+            } catch (error) {
+                if (
+                    error instanceof TelebirrVerificationError &&
+                    error.kind === 'transport'
+                ) {
+                    recordProxyTransportFailure(descriptor, cooldownMs);
+                }
+                return {
+                    id: descriptor.id,
+                    label: descriptor.label,
+                    role: descriptor.role,
+                    status: 'unavailable',
+                    latencyMs: Math.round(performance.now() - startedAt)
+                };
+            }
+        })
+    );
+    const active = routes.find(route => route.status === 'operational') ?? null;
+    const activeDescriptor = active
+        ? descriptors.find(descriptor => descriptor.id === active.id)
+        : null;
+    activeTelebirrProxyUrl = activeDescriptor?.url ?? null;
+
+    return {
+        activeRouteId: active?.id ?? null,
+        preferredRouteAvailable:
+            routes.find(route => route.role === 'preferred')?.status === 'operational',
+        routes
+    };
+}
+
 export async function verifyTelebirr(reference: string): Promise<TelebirrReceipt | null> {
     const primaryUrl = "https://transactioninfo.ethiotelecom.et/receipt/";
-
-
-    const envProxies = process.env.FALLBACK_PROXIES || "";
-    const fallbackProxies = envProxies.split(',')
-        .map(url => url.trim())
-        .filter(url => url.length > 0);
+    const proxyDescriptors = getTelebirrProxyDescriptors(process.env);
     const skipPrimary = process.env.SKIP_PRIMARY_VERIFICATION === "true";
 
     if (!skipPrimary) {
-        logger.info(`Attempting primary verification for: ${reference}`);
+        logger.info('Attempting primary Telebirr verification.');
         const primaryResult = await fetchFromPrimarySource(reference, primaryUrl);
 
         if (primaryResult && isValidReceipt(primaryResult)) {
@@ -478,26 +923,23 @@ export async function verifyTelebirr(reference: string): Promise<TelebirrReceipt
         logger.info(`Skipping primary verifier (SKIP_PRIMARY_VERIFICATION=true).`);
     }
 
-    if (fallbackProxies.length === 0 && skipPrimary) {
+    if (proxyDescriptors.length === 0 && skipPrimary) {
         logger.error("CRITICAL: Primary check skipped, but no FALLBACK_PROXIES defined in .env!");
         return null;
     }
 
-    for (const proxyUrl of fallbackProxies) {
-        try {
-            logger.info(`Attempting verification with proxy: ${proxyUrl}`);
-            const fallbackResult = await fetchFromProxySource(reference, proxyUrl);
-
-            if (fallbackResult && isValidReceipt(fallbackResult)) {
-                logger.info(`Successfully verified using proxy: ${proxyUrl}`);
-                return fallbackResult;
-            }
-        } catch (error) {
-            logger.warn(`Proxy ${proxyUrl} failed or timed out. Trying next...`);
+    if (proxyDescriptors.length > 0) {
+        const fallbackResult = await verifyWithTelebirrProxyPool(
+            reference,
+            proxyDescriptors,
+            process.env
+        );
+        if (fallbackResult) {
+            return fallbackResult;
         }
     }
 
-    logger.error(`All primary and proxy verification methods failed for reference: ${reference}`);
+    logger.error('All Telebirr verification methods failed.');
     return null;
 }
 

--- a/src/tests/statusProbeService.test.ts
+++ b/src/tests/statusProbeService.test.ts
@@ -1,10 +1,85 @@
 import assert from 'node:assert/strict';
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from 'node:http';
+import type { AddressInfo } from 'node:net';
 import test from 'node:test';
 import {
   classifyProbeResult,
   getStatusCapabilities,
+  isHealthyProbeResultCode,
   runStatusProviderProbe,
 } from '../services/statusProbeService';
+import {
+  getTelebirrProxyDescriptors,
+  verifyTelebirr,
+} from '../services/verifyTelebirr';
+
+const TELEBIRR_ENV_KEYS = [
+  'FALLBACK_PROXIES',
+  'SKIP_PRIMARY_VERIFICATION',
+  'TELEBIRR_HEDGE_DELAY_MS',
+  'TELEBIRR_MAX_PARALLEL_PROXIES',
+  'TELEBIRR_PROXY_COOLDOWN_MS',
+  'TELEBIRR_PROXY_KEY',
+  'TELEBIRR_PROXY_TIMEOUT_MS',
+  'TELEBIRR_TOTAL_TIMEOUT_MS',
+] as const;
+
+async function listen(
+  handler: (request: IncomingMessage, response: ServerResponse) => void,
+): Promise<{ server: Server; proxyUrl: string }> {
+  const server = createServer(handler);
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+  const address = server.address() as AddressInfo;
+  return {
+    server,
+    proxyUrl: `http://127.0.0.1:${address.port}/?reference=`,
+  };
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close(error => (error ? reject(error) : resolve()));
+  });
+}
+
+function validTelebirrResponse(receiptNo: string): string {
+  return JSON.stringify({
+    success: true,
+    data: {
+      payerName: 'Status test payer',
+      transactionStatus: 'Completed',
+      receiptNo,
+    },
+  });
+}
+
+async function withTelebirrEnv(
+  values: Record<string, string>,
+  operation: () => Promise<void>,
+): Promise<void> {
+  const previous = new Map(
+    TELEBIRR_ENV_KEYS.map(key => [key, process.env[key]]),
+  );
+  try {
+    for (const key of TELEBIRR_ENV_KEYS) delete process.env[key];
+    Object.assign(process.env, values);
+    await operation();
+  } finally {
+    for (const key of TELEBIRR_ENV_KEYS) {
+      const value = previous.get(key);
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
 
 test('returns a redacted not-configured provider result without contacting upstreams', async () => {
   const result = await runStatusProviderProbe('telebirr', {});
@@ -56,6 +131,11 @@ test('classifies healthy, slow, invalid, and unavailable results', () => {
   );
 });
 
+test('treats an active fallback Telebirr relay as a healthy degraded path', () => {
+  assert.equal(isHealthyProbeResultCode('FALLBACK_ACTIVE'), true);
+  assert.equal(isHealthyProbeResultCode('ALL_ROUTES_UNAVAILABLE'), false);
+});
+
 test('reports capability configuration without consuming credits', () => {
   const capabilities = getStatusCapabilities({
     MISTRAL_API_KEY: 'configured',
@@ -64,4 +144,168 @@ test('reports capability configuration without consuming credits', () => {
   assert.equal(capabilities.batchVerification.configured, true);
   assert.equal(capabilities.imageVerification.configured, true);
   assert.equal(capabilities.hostedCommerce.configured, true);
+});
+
+test('creates safe public Telebirr relay labels without exposing fallback URLs', () => {
+  const descriptors = getTelebirrProxyDescriptors({
+    FALLBACK_PROXIES:
+      'https://leul.et/telebirr?reference=,https://private-relay.example/check?reference=',
+    TELEBIRR_PROXY_LABELS: 'leul.et,Community relay 1',
+  });
+  assert.deepEqual(
+    descriptors.map(({ id, label, role }) => ({ id, label, role })),
+    [
+      { id: 'preferred', label: 'leul.et', role: 'preferred' },
+      { id: 'relay-1', label: 'Community relay 1', role: 'fallback' },
+    ],
+  );
+});
+
+test('hedges a slow preferred relay and reuses the winning fallback', async () => {
+  let preferredRequests = 0;
+  let fallbackRequests = 0;
+  const preferred = await listen((_request, response) => {
+    preferredRequests += 1;
+    setTimeout(() => {
+      if (response.destroyed) return;
+      response.setHeader('content-type', 'application/json');
+      response.end(validTelebirrResponse('PREFERRED'));
+    }, 300);
+  });
+  const fallback = await listen((_request, response) => {
+    fallbackRequests += 1;
+    response.setHeader('content-type', 'application/json');
+    response.end(validTelebirrResponse('FALLBACK'));
+  });
+
+  try {
+    await withTelebirrEnv(
+      {
+        FALLBACK_PROXIES: `${preferred.proxyUrl},${fallback.proxyUrl}`,
+        SKIP_PRIMARY_VERIFICATION: 'true',
+        TELEBIRR_HEDGE_DELAY_MS: '40',
+        TELEBIRR_MAX_PARALLEL_PROXIES: '2',
+        TELEBIRR_PROXY_COOLDOWN_MS: '5000',
+        TELEBIRR_PROXY_TIMEOUT_MS: '1000',
+        TELEBIRR_TOTAL_TIMEOUT_MS: '1500',
+      },
+      async () => {
+        const first = await verifyTelebirr('TEST-REFERENCE');
+        assert.equal(first?.receiptNo, 'FALLBACK');
+        assert.equal(preferredRequests, 1);
+        assert.equal(fallbackRequests, 1);
+
+        const second = await verifyTelebirr('TEST-REFERENCE');
+        assert.equal(second?.receiptNo, 'FALLBACK');
+        await new Promise(resolve => setTimeout(resolve, 75));
+        assert.equal(
+          preferredRequests,
+          1,
+          'the known active fallback should satisfy the request before another hedge',
+        );
+        assert.equal(fallbackRequests, 2);
+      },
+    );
+  } finally {
+    await Promise.all([
+      closeServer(preferred.server),
+      closeServer(fallback.server),
+    ]);
+  }
+});
+
+test('opens the circuit for a transport-failing relay', async () => {
+  let preferredRequests = 0;
+  const preferred = await listen((_request, response) => {
+    preferredRequests += 1;
+    response.statusCode = 503;
+    response.end('unavailable');
+  });
+  const fallback = await listen((_request, response) => {
+    setTimeout(() => {
+      if (response.destroyed) return;
+      response.setHeader('content-type', 'application/json');
+      response.end(validTelebirrResponse('CIRCUIT-FALLBACK'));
+    }, 80);
+  });
+
+  try {
+    await withTelebirrEnv(
+      {
+        FALLBACK_PROXIES: `${preferred.proxyUrl},${fallback.proxyUrl}`,
+        SKIP_PRIMARY_VERIFICATION: 'true',
+        TELEBIRR_HEDGE_DELAY_MS: '20',
+        TELEBIRR_MAX_PARALLEL_PROXIES: '2',
+        TELEBIRR_PROXY_COOLDOWN_MS: '5000',
+        TELEBIRR_PROXY_TIMEOUT_MS: '500',
+        TELEBIRR_TOTAL_TIMEOUT_MS: '1000',
+      },
+      async () => {
+        assert.equal(
+          (await verifyTelebirr('TEST-REFERENCE'))?.receiptNo,
+          'CIRCUIT-FALLBACK',
+        );
+        assert.equal(
+          (await verifyTelebirr('TEST-REFERENCE'))?.receiptNo,
+          'CIRCUIT-FALLBACK',
+        );
+        assert.equal(
+          preferredRequests,
+          1,
+          'the failed relay should be skipped during its cooldown',
+        );
+      },
+    );
+  } finally {
+    await Promise.all([
+      closeServer(preferred.server),
+      closeServer(fallback.server),
+    ]);
+  }
+});
+
+test('does not open a relay circuit for a missing receipt', async () => {
+  let preferredHasReceipt = false;
+  let preferredRequests = 0;
+  const preferred = await listen((_request, response) => {
+    preferredRequests += 1;
+    response.setHeader('content-type', 'application/json');
+    response.end(
+      preferredHasReceipt
+        ? validTelebirrResponse('RECOVERED-PREFERRED')
+        : JSON.stringify({ success: false, error: 'Receipt not found' }),
+    );
+  });
+  const fallback = await listen((_request, response) => {
+    response.setHeader('content-type', 'application/json');
+    response.end(JSON.stringify({ success: false, error: 'Receipt not found' }));
+  });
+
+  try {
+    await withTelebirrEnv(
+      {
+        FALLBACK_PROXIES: `${preferred.proxyUrl},${fallback.proxyUrl}`,
+        SKIP_PRIMARY_VERIFICATION: 'true',
+        TELEBIRR_HEDGE_DELAY_MS: '20',
+        TELEBIRR_MAX_PARALLEL_PROXIES: '2',
+        TELEBIRR_PROXY_COOLDOWN_MS: '5000',
+        TELEBIRR_PROXY_TIMEOUT_MS: '500',
+        TELEBIRR_TOTAL_TIMEOUT_MS: '1000',
+      },
+      async () => {
+        assert.equal(await verifyTelebirr('MISSING-REFERENCE'), null);
+        preferredHasReceipt = true;
+        assert.equal(
+          (await verifyTelebirr('TEST-REFERENCE'))?.receiptNo,
+          'RECOVERED-PREFERRED',
+        );
+        assert.equal(preferredRequests, 2);
+      },
+    );
+  } finally {
+    await Promise.all([
+      closeServer(preferred.server),
+      closeServer(fallback.server),
+    ]);
+  }
 });

--- a/src/types/statusProbe.ts
+++ b/src/types/statusProbe.ts
@@ -11,11 +11,27 @@ export type StatusProvider = (typeof STATUS_PROVIDERS)[number];
 
 export type StatusProbeResultCode =
   | 'PROBE_OK'
+  | 'FALLBACK_ACTIVE'
   | 'UPSTREAM_SLOW'
   | 'UPSTREAM_TIMEOUT'
   | 'UPSTREAM_UNAVAILABLE'
+  | 'ALL_ROUTES_UNAVAILABLE'
   | 'UNEXPECTED_RESPONSE'
   | 'PROBE_NOT_CONFIGURED';
+
+export interface TelebirrRouteStatus {
+  id: string;
+  label: string;
+  role: 'preferred' | 'fallback';
+  status: 'operational' | 'unavailable';
+  latencyMs: number | null;
+}
+
+export interface TelebirrProbeDetails {
+  activeRouteId: string | null;
+  preferredRouteAvailable: boolean;
+  routes: TelebirrRouteStatus[];
+}
 
 export interface StatusProbeResult {
   provider: StatusProvider;
@@ -24,6 +40,7 @@ export interface StatusProbeResult {
   durationMs: number;
   checkedAt: string;
   resultCode: StatusProbeResultCode;
+  telebirr?: TelebirrProbeDetails;
 }
 
 export interface StatusCapabilities {


### PR DESCRIPTION
## What changed

- adds health-aware Telebirr relay routing with a preferred route, one-second hedged fallback, per-route circuit cooldown, bounded concurrency, and a total request deadline
- reuses the last successful relay for subsequent requests
- keeps missing receipts separate from transport failures so invalid references do not mark a relay down
- publishes safe per-relay health metadata for the Veritas status page without exposing relay URLs or keys
- redacts receipt references, proxy keys, and receipt data from operational logs
- documents the runtime relay variables and updates deployment configuration for the split CBE probes

## Why

The local `main` branch had diverged from GitHub `main`: it contained the intended Telebirr work on an old base and an accidentally committed `render.yaml` conflict. This branch was rebuilt from the current GitHub `main` and contains only the six intended files, avoiding rollback of the already-merged Veritas work.

## Impact

When the preferred `leul.et` relay is slow or unavailable, another healthy relay begins after one second. The first valid result wins, and the working fallback is preferred on following requests. Failed routes cool down for 60 seconds instead of adding repeated 30-second delays.

## Validation

- `pnpm test`
- Prisma Client generation completed
- TypeScript build passed
- 10/10 API tests passed
- conflict-marker scan passed
- staged diff check passed
